### PR TITLE
Allow db override, add options param to insert

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,12 +1,14 @@
-var config = require('../config')
-var debug = require('debug')('api:mongodb')
-var EventEmitter = require('events').EventEmitter
-var metadata = require('@dadi/metadata')
-var mongodb = require('mongodb')
-var MongoClient = mongodb.MongoClient
-var ObjectID = require('mongodb').ObjectID
-var qs = require('querystring')
-var util = require('util')
+'use strict'
+
+const config = require('../config')
+const debug = require('debug')('api:mongodb')
+const EventEmitter = require('events').EventEmitter
+const metadata = require('@dadi/metadata')
+const mongodb = require('mongodb')
+const MongoClient = mongodb.MongoClient
+const ObjectID = require('mongodb').ObjectID
+const qs = require('querystring')
+const util = require('util')
 
 /**
  * @typedef ConnectionOptions
@@ -30,7 +32,7 @@ var util = require('util')
  * @classdesc DataStore adapter for using MongoDB with DADI API
  * @implements EventEmitter
  */
-var DataStore = function DataStore (options) {
+const DataStore = function DataStore (options) {
   this.config = options || config.get()
   this._connections = []
   this._mongoClient = new MongoClient()
@@ -131,9 +133,10 @@ DataStore.prototype.find = function (query, collection, options, schema) {
           cursor.toArray((err, result) => {
             if (err) return reject(err)
 
-            var returnData = {}
-            returnData.results = result
-            returnData.metadata = this.getMetadata(options, count)
+            const returnData = {
+              results: result,
+              metadata: this.getMetadata(options, count)
+            }
 
             return resolve(returnData)
           })
@@ -148,11 +151,12 @@ DataStore.prototype.find = function (query, collection, options, schema) {
  *
  * @param {Object|Array} data - a single document or an Array of documents to insert
  * @param {string} collection - the name of the collection to insert into
+ * @param {object} options - options to modify the query
  * @param {Object} schema - the JSON schema for the collection
  * @returns {Promise.<Array, Error>} A promise that returns an Array of inserted documents,
  *     or an Error if the operation fails
  */
-DataStore.prototype.insert = function (data, collection, schema) {
+DataStore.prototype.insert = function (data, collection, options, schema) {
   debug('insert into %s %o', collection, data)
 
   // make an Array of documents if an Object has been provided
@@ -166,7 +170,7 @@ DataStore.prototype.insert = function (data, collection, schema) {
   })
 
   return new Promise((resolve, reject) => {
-    this.database.collection(collection).insertMany(data, (err, result) => {
+    this.database.collection(collection).insertMany(data, options, (err, result) => {
       if (err) {
         return reject(err)
       }
@@ -182,6 +186,7 @@ DataStore.prototype.insert = function (data, collection, schema) {
  * @param {object} query - the query that selects documents for update
  * @param {string} collection - the name of the collection to update documents in
  * @param {object} update - the update for the documents matching the query
+ * @param {object} options - options to modify the query
  * @param {object} schema - the JSON schema for the collection
  * @returns {Promise.<Array, Error>} A promise that returns an Array of updated documents,
  *     or an Error if the operation fails
@@ -233,7 +238,7 @@ DataStore.prototype.stats = function (collection, options) {
     this.database.collection(collection).stats(options, (err, stats) => {
       if (err) return reject(err)
 
-      var result = {
+      const result = {
         count: stats.count,
         size: stats.size,
         averageObjectSize: stats.avgObjSize,
@@ -264,7 +269,7 @@ DataStore.prototype.getMetadata = function (options, count) {
 DataStore.prototype.index = function (collection, indexes) {
   return new Promise((resolve, reject) => {
     // Create an index on the specified field(s)
-    var results = []
+    let results = []
 
     indexes.forEach((index, idx) => {
       if (Object.keys(index.keys).length === 1 && Object.keys(index.keys)[0] === '_id') {
@@ -346,12 +351,12 @@ DataStore.prototype.createObjectIdFromString = function (query, schema) {
       return
     }
 
-    var fieldSettings = getSchemaOrParent(key, schema)
-    var type = fieldSettings ? fieldSettings.type : undefined
+    const fieldSettings = getSchemaOrParent(key, schema)
+    const type = fieldSettings ? fieldSettings.type : undefined
 
     if (key === '$in') {
       if (typeof query[key] === 'object' && Array.isArray(query[key])) {
-        var arr = query[key]
+        let arr = query[key]
 
         arr.forEach((value, key) => {
           if (typeof value === 'string' && ObjectID.isValid(value) && value.match(/^[a-fA-F0-9]{24}$/)) {
@@ -376,15 +381,15 @@ DataStore.prototype.createObjectIdFromString = function (query, schema) {
 }
 
 DataStore.prototype.convertObjectIdsForSave = function (obj, schema) {
-  // var keys = Object.keys(schema).filter((key) => { return schema[key].type === 'ObjectID' })
+  // let keys = Object.keys(schema).filter((key) => { return schema[key].type === 'ObjectID' })
   // keys.push('_id')
 
   Object.keys(obj).forEach((key) => {
-    var fieldSettings = getSchemaOrParent(key, schema)
-    var type = fieldSettings ? fieldSettings.type : undefined
+    const fieldSettings = getSchemaOrParent(key, schema)
+    const type = fieldSettings ? fieldSettings.type : undefined
 
     if (typeof obj[key] === 'object' && Array.isArray(obj[key])) {
-      var arr = obj[key]
+      let arr = obj[key]
 
       arr.forEach((value, key) => {
         if (typeof value === 'string' && type === 'ObjectID' && ObjectID.isValid(value) && value.match(/^[a-fA-F0-9]{24}$/)) {
@@ -408,7 +413,7 @@ DataStore.prototype.convertObjectIdsForSave = function (obj, schema) {
  */
 function getSchemaOrParent (key, schema) {
   // use the key as specified or the first part after splitting on '.'
-  var keyOrParent = (key.split('.').length > 1) ? key.split('.')[0] : key
+  const keyOrParent = (key.split('.').length > 1) ? key.split('.')[0] : key
 
   if (schema[keyOrParent]) {
     return schema[keyOrParent]
@@ -438,15 +443,17 @@ DataStore.prototype.getConnectionOptions = function (overrideOptions) {
 
   debug('connection override options %o', overrideOptions)
 
-  var connectionOptions = Object.assign({}, this.config)
+  let connectionOptions = Object.assign({}, this.config)
 
-  // console.log('>>>>>> db config overrideOptions')
-  // console.log(this.config[overrideOptions.database])
-  // console.log('<<<<<<')
+  const allowOverride = (this.config.enableCollectionDatabases || overrideOptions.override) &&
+    (overrideOptions.database &&
+    overrideOptions.database !== connectionOptions.databaase)
 
-  if ((this.config.enableCollectionDatabases || overrideOptions.auth) && overrideOptions.database && this.config[overrideOptions.database]) {
+  // override ok and config block exists with the specified database key
+  if (allowOverride && this.config[overrideOptions.database]) {
     connectionOptions = Object.assign(connectionOptions, { database: overrideOptions.database }, this.config[overrideOptions.database])
   }
+
 
   debug('connectionOptions %o', connectionOptions)
 
@@ -462,7 +469,7 @@ DataStore.prototype.getConnectionOptions = function (overrideOptions) {
  *
  */
 DataStore.prototype.constructConnectionString = function (options) {
-  var connectionOptions = Object.assign({
+  let connectionOptions = Object.assign({
     options: {}
   }, options)
 
@@ -474,9 +481,9 @@ DataStore.prototype.constructConnectionString = function (options) {
   if (options.maxPoolSize) connectionOptions.options['maxPoolSize'] = options.maxPoolSize
   if (options.readPreference) connectionOptions.options['readPreference'] = options.readPreference
 
-  var credentials = this.credentials(connectionOptions)
-  var hosts = this.hosts(connectionOptions.hosts)
-  var optionsString = this.encodeOptions(connectionOptions.options)
+  const credentials = this.credentials(connectionOptions)
+  const hosts = this.hosts(connectionOptions.hosts)
+  const optionsString = this.encodeOptions(connectionOptions.options)
 
   return `mongodb://${credentials}${hosts}/${connectionOptions.database}${optionsString}`
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -454,7 +454,6 @@ DataStore.prototype.getConnectionOptions = function (overrideOptions) {
     connectionOptions = Object.assign(connectionOptions, { database: overrideOptions.database }, this.config[overrideOptions.database])
   }
 
-
   debug('connectionOptions %o', connectionOptions)
 
   // required config fields

--- a/test/unit/operations.js
+++ b/test/unit/operations.js
@@ -97,7 +97,7 @@ describe('MongoDB Operations', function () {
       }
 
       mongodb.connect().then(() => {
-        mongodb.insert(doc, 'test', helper.getModelSchema()).then(result => {
+        mongodb.insert(doc, 'test', {}, helper.getModelSchema()).then(result => {
           result.should.be.Array
           result.length.should.eql(1)
           should.exist(result[0].fieldName)
@@ -124,7 +124,7 @@ describe('MongoDB Operations', function () {
       ]
 
       mongodb.connect().then(() => {
-        mongodb.insert(docs, 'test', helper.getModelSchema()).then(result => {
+        mongodb.insert(docs, 'test', {}, helper.getModelSchema()).then(result => {
           result.should.be.Array
           result.length.should.eql(2)
           should.exist(result[0].fieldName)
@@ -149,7 +149,7 @@ describe('MongoDB Operations', function () {
       var doc = { fieldName: 'foo' }
 
       mongodb.connect().then(() => {
-        mongodb.insert(doc, 'test', helper.getModelSchema()).then(result => {
+        mongodb.insert(doc, 'test', {}, helper.getModelSchema()).then(result => {
           mongodb.stats('test', {}).then(result => {
             should.exist(result.count)
             result.count.should.eql(1)
@@ -169,7 +169,7 @@ describe('MongoDB Operations', function () {
       var doc = { fieldName: 'foo' }
 
       mongodb.connect().then(() => {
-        mongodb.insert(doc, 'test', helper.getModelSchema()).then(result => {
+        mongodb.insert(doc, 'test', {}, helper.getModelSchema()).then(result => {
           var inserted = result[0]
           mongodb.find({ _id: inserted._id }, 'test', {}, helper.getModelSchema()).then(result => {
             result.results.should.be.Array
@@ -189,7 +189,7 @@ describe('MongoDB Operations', function () {
       var doc = { fieldName: 'foo' }
 
       mongodb.connect().then(() => {
-        mongodb.insert(doc, 'test', helper.getModelSchema()).then(result => {
+        mongodb.insert(doc, 'test', {}, helper.getModelSchema()).then(result => {
           var inserted = result[0]
           mongodb.find({ fieldName: inserted.fieldName }, 'test', {}, helper.getModelSchema()).then(result => {
             result.results.should.be.Array
@@ -209,7 +209,7 @@ describe('MongoDB Operations', function () {
       var docs = [{ fieldName: 'foo1' }, { fieldName: 'foo2' }]
 
       mongodb.connect().then(() => {
-        mongodb.insert(docs, 'test', helper.getModelSchema()).then(result => {
+        mongodb.insert(docs, 'test', {}, helper.getModelSchema()).then(result => {
 
           mongodb.find({ fieldName: { '$containsAny': ['foo1'] } }, 'test', {}, helper.getModelSchema()).then(result => {
             result.results.should.be.Array
@@ -229,7 +229,7 @@ describe('MongoDB Operations', function () {
       var docs = [{ fieldName: 'foo1' }, { fieldName: 'foo2' }]
 
       mongodb.connect().then(() => {
-        mongodb.insert(docs, 'test', helper.getModelSchema()).then(result => {
+        mongodb.insert(docs, 'test', {}, helper.getModelSchema()).then(result => {
 
           mongodb.find({ fieldName: /foo1/ }, 'test', {}, helper.getModelSchema()).then(result => {
             result.results.should.be.Array
@@ -249,7 +249,7 @@ describe('MongoDB Operations', function () {
       var doc = { fieldName: 'foo' }
 
       mongodb.connect().then(() => {
-        mongodb.insert(doc, 'test', helper.getModelSchema()).then(result => {
+        mongodb.insert(doc, 'test', {}, helper.getModelSchema()).then(result => {
           var inserted = result[0]
           mongodb.find({ fieldName: inserted.fieldName }, 'test', {}, helper.getModelSchema()).then(result => {
             should.exist(result.metadata)
@@ -268,7 +268,7 @@ describe('MongoDB Operations', function () {
       var docs = [{ fieldName: 'foo1' }, { fieldName: 'foo2' }]
 
       mongodb.connect().then(() => {
-        mongodb.insert(docs, 'test', helper.getModelSchema()).then(result => {
+        mongodb.insert(docs, 'test', {}, helper.getModelSchema()).then(result => {
 
           var query = [
             { $match: { fieldName: 'foo1' } }
@@ -300,7 +300,7 @@ describe('MongoDB Operations', function () {
       }
 
       mongodb.connect().then(() => {
-        mongodb.insert(docs, 'test', helper.getExtendedModelSchema()).then(result => {
+        mongodb.insert(docs, 'test', {}, helper.getExtendedModelSchema()).then(result => {
 
           var query = [
             {
@@ -338,7 +338,7 @@ describe('MongoDB Operations', function () {
       }
 
       mongodb.connect().then(() => {
-        mongodb.insert(docs, 'test', helper.getExtendedModelSchema()).then(result => {
+        mongodb.insert(docs, 'test', {}, helper.getExtendedModelSchema()).then(result => {
 
           var query = [
             { $match: { 'field2': { '$gte': 1 } } },
@@ -369,7 +369,7 @@ describe('MongoDB Operations', function () {
       }
 
       mongodb.connect().then(() => {
-        mongodb.insert(doc, 'test', helper.getModelSchema()).then(result => {
+        mongodb.insert(doc, 'test', {}, helper.getModelSchema()).then(result => {
           let id = result[0]._id
           let update = { '$set': { fieldName: 'fooXX' } }
 
@@ -398,7 +398,7 @@ describe('MongoDB Operations', function () {
       ]
 
       mongodb.connect().then(() => {
-        mongodb.insert(docs, 'test', helper.getModelSchema()).then(result => {
+        mongodb.insert(docs, 'test', {}, helper.getModelSchema()).then(result => {
           let id = result[0]._id
           let query = { fieldName: { '$regex': '^foo' } }
 
@@ -424,7 +424,7 @@ describe('MongoDB Operations', function () {
       }
 
       mongodb.connect().then(() => {
-        mongodb.insert(doc, 'test', helper.getModelSchema()).then(result => {
+        mongodb.insert(doc, 'test', {}, helper.getModelSchema()).then(result => {
           let id = result[0]._id
           let update = { '$set': { fieldName: 'fooXX' } }
 
@@ -453,7 +453,7 @@ describe('MongoDB Operations', function () {
       ]
 
       mongodb.connect().then(() => {
-        mongodb.insert(docs, 'test', helper.getModelSchema()).then(result => {
+        mongodb.insert(docs, 'test', {}, helper.getModelSchema()).then(result => {
           let id = result[0]._id
           let query = { fieldName: { '$regex': '^foo' } }
 


### PR DESCRIPTION
BREAKING CHANGE: the `insert()` method signature has changed, now accepting an `options` argument:

```
DataStore.prototype.insert = function (data, collection, options, schema)
```