### PR TITLE
Add internalProperties to the settings block

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,5 +5,6 @@ module.exports = require(
 )
 
 module.exports.settings = {
-  connectWithCollection: true
+  connectWithCollection: true,
+  internalProperties: ['_id']
 }


### PR DESCRIPTION
This PR adds an `internalProperties` array to the `settings` export, in line with recent changes to API.