### PR TITLE
v6.0.2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -308,11 +308,21 @@ class DataStore extends EventEmitter {
     let query = params.query
     const {collection, options = {}, schema} = params
 
+    // Patch fields -> projection for current MongoDB driver
+    // See https://mongodb.github.io/node-mongodb-native/6.10/interfaces/FindOptions.html#projection
+    const mongoOptions = {...options}
+    if (mongoOptions.fields) {
+      mongoOptions.projection = mongoOptions.fields
+      delete mongoOptions.fields
+    }
+
     // Handle array query as aggregation
     if (Array.isArray(query)) {
       debug('aggregate in %s %o %o', collection, query, options)
 
-      const cursor = this.#db.collection(collection).aggregate(query, options)
+      const cursor = this.#db
+        .collection(collection)
+        .aggregate(query, mongoOptions)
       return cursor.toArray()
     }
 
@@ -322,7 +332,7 @@ class DataStore extends EventEmitter {
 
     try {
       const count = await this.#db.collection(collection).countDocuments(query)
-      const cursor = this.#db.collection(collection).find(query, options)
+      const cursor = this.#db.collection(collection).find(query, mongoOptions)
       const documents = await cursor.toArray()
 
       return {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dadi/api-mongodb",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "A MongoDB adapter for DADI API",
   "keywords": [
     "dadi",


### PR DESCRIPTION
This patch fixes an issue with MongoDB projections not working.

At some point between `mongodb` v2.x (used by v5.x of this adapter and below) and the current version, v6.8, the `fields` option (property) was renamed to `projection`. This was not migrated correctly within the adapter.

To preserve backward compatibility, the property is renamed internally while `fields` is still exposed through the `DataStore.find` method. It is also possible to pass `projection` directly.